### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "install": "^0.12.2",
-    "npm": "^6.9.0",
     "primeicons": "^1.0.0",
     "primereact": "^3.1.4",
     "react": "^16.8.6",


### PR DESCRIPTION

Hello joaogj!

It seems like you have npm as one of your (dev-) dependency in altran-test.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
